### PR TITLE
Accept usernames and channel names as targets

### DIFF
--- a/lib/lita/handlers/hook_forward.rb
+++ b/lib/lita/handlers/hook_forward.rb
@@ -4,6 +4,7 @@ module Lita
 
       #noinspection RubyArgCount
       http.get '/lita/hook-forward', :receive
+      http.post '/lita/hook-forward', :receive
 
       def self.default_config(handler_config)
         handler_config.default_room = nil

--- a/lib/lita/handlers/hook_forward.rb
+++ b/lib/lita/handlers/hook_forward.rb
@@ -12,12 +12,22 @@ module Lita
       def receive(request, response)
         message = request.params['message']
         targets = request.params['targets'] || Lita.config.handlers.hook_forward.default_room || nil
-        rooms = []
+        target_names = []
+
         targets.split(',').each do |param_target|
-          rooms << param_target
+          target_names << param_target
         end
-        rooms.each do |room|
-          target = Source.new(room: room)
+
+        target_names.each do |name|
+          target = if name[0] == '#'
+                     name = name[1..-1]
+                     lita_room = Lita::Room.find_by_name(name)
+                     Lita::Source.new(room: lita_room.id)
+                   else
+                     user = Lita::User.fuzzy_find(name)
+                     Lita::Source.new(user: user)
+                   end
+
           robot.send_message(target, message)
         end
       end

--- a/spec/lita/handlers/hook_forward_spec.rb
+++ b/spec/lita/handlers/hook_forward_spec.rb
@@ -17,8 +17,12 @@ describe Lita::Handlers::HookForward, lita_handler: true do
     before { Lita.config.handlers.hook_forward.default_room = '#baz' }
 
     it 'sends a notification message to the applicable rooms' do
+      fake_room = Object.new
+      allow(Lita::Room).to receive(:find_by_name).and_return(fake_room)
+      allow(fake_room).to receive(:id).and_return('FAKE_ID')
+
       expect(robot).to receive(:send_message) do |target, message|
-        expect(target.room).to eq('#baz')
+        expect(target.room).to eq('FAKE_ID')
         expect(message).to include('hello')
       end
       subject.receive(request, response)


### PR DESCRIPTION
Hi @milo-ft

 I suspect I'm missing something as this is not the first handler I've came across that does not handle Slack channel names but only Slack channel IDs. This PR might not be fully valid.

Also, the other part of this PR also include allowing users to be targets
